### PR TITLE
More aggressive integer conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     - Before: Numbers that are valid 32-bit signed/unsigned integers (`i32`/`u32`) are converted into `int`. Others are converted into `float`.
     - After: Non-whole numbers are converted into `float`. Whole-number conversion is controlled by the parameter `integer_conversion`. The valid values are, in the order of increasing aggressiveness:
         - `never`: All numbers are converted into `float`.
-        - `i32`: Only valid 32-bit integers are converted into `int`. This is the default, for consistency with other common embedded JavaScript engines.
-        - `safe`: Whole numbers within the [safe-integer range](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isSafeInteger) are converted into `int`. This is arguably the nicer behavior.
+        - `i32`: Only valid 32-bit integers are converted into `int`. This seems to be the common behavior of other embedded JavaScript engines.
+        - `safe`: Whole numbers within the [safe-integer range](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isSafeInteger) are converted into `int`. This is the default.
         - `aggressive`: Even [unsafe integers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER) are converted into `int`.
 
 ## [0.4.0] - 2024-03-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 ### Changed
-- JavaScript numbers that are [safe integers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isSafeInteger) can now be converted to Python `int` via the flag `convert_safe_integers`.
-    - Previously they were converted to `float`, unless they are valid 32-bit integers.
-    - [Unsafe integers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER) are still converted to `float` instead.
+- JavaScript numbers that are [safe integers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isSafeInteger) can now be converted into Python `int` via the flag `convert_safe_integers`.
+    - Before:
+        - Numbers that are valid 32-bit signed/unsigned integers (`i32`/`u32`) are converted into `int`.
+        - Others are converted into `float`.
+    - After:
+        - Numbers that are valid 32-bit signed integers are converted into `int`.
+        - Numbers that are safe integers, but outside of `i32`, are converted into `float` (even if they are inside `u32`). If the flag is `True`, they are converted into `int`. The latter is arguably nicer behavior, but not the default, for consistency with other common embedded JavaScript engines.
+        - Other numbers are convented into `float`, including [unsafe integers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER).
 
 ## [0.4.0] - 2024-03-03
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 ### Changed
-- JavaScript whole numbers larger than 32 bits are now converted to Python `int`.
-    - Previously they were converted to `float`.
-    - Even unsafe whole numbers (larger than 53 bits) are converted.
+- JavaScript numbers that are [safe integers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isSafeInteger) can now be converted to Python `int` via the flag `convert_safe_integers`.
+    - Previously they were converted to `float`, unless they are valid 32-bit integers.
+    - [Unsafe integers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER) are still converted to `float` instead.
 
 ## [0.4.0] - 2024-03-03
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Changed
+- JavaScript whole numbers larger than 32 bits are now converted to Python `int`.
+    - Previously they were converted to `float`.
+    - Even unsafe whole numbers (larger than 53 bits) are converted.
 
 ## [0.4.0] - 2024-03-03
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 ### Changed
-- JavaScript numbers that are [safe integers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isSafeInteger) can now be converted into Python `int` via the flag `convert_safe_integers`.
-    - Before:
-        - Numbers that are valid 32-bit signed/unsigned integers (`i32`/`u32`) are converted into `int`.
-        - Others are converted into `float`.
-    - After:
-        - Numbers that are valid 32-bit signed integers are converted into `int`.
-        - Numbers that are safe integers, but outside of `i32`, are converted into `float` (even if they are inside `u32`). If the flag is `True`, they are converted into `int`. The latter is arguably nicer behavior, but not the default, for consistency with other common embedded JavaScript engines.
-        - Other numbers are convented into `float`, including [unsafe integers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER).
+- The behavior of whether a JavaScript number is converted into Python `float` or `int` has changed.
+    - Before: Numbers that are valid 32-bit signed/unsigned integers (`i32`/`u32`) are converted into `int`. Others are converted into `float`.
+    - After: Non-whole numbers are converted into `float`. Whole-number conversion is controlled by the parameter `integer_conversion`. The valid values are, in the order of increasing aggressiveness:
+        - `never`: All numbers are converted into `float`.
+        - `i32`: Only valid 32-bit integers are converted into `int`. This is the default, for consistency with other common embedded JavaScript engines.
+        - `safe`: Whole numbers within the [safe-integer range](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isSafeInteger) are converted into `int`. This is arguably the nicer behavior.
+        - `aggressive`: Even [unsafe integers](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER) are converted into `int`.
 
 ## [0.4.0] - 2024-03-03
 ### Added

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,11 +12,13 @@ mod types;
 
 /// A wrapper around deno_core's JsRuntime.
 ///
-/// Instances of this class can only be used from the thread they were created on.
-/// If they are sent to another thread, they will panic when used.
+/// Instances of this class can only be used from the thread they were
+/// created on. If they are sent to another thread, they will panic when
+/// used.
 ///
-/// Each thread is associated with at most one instance. After the constructor is called once,
-/// subsequent calls on the same thread return the same instance.
+/// Each thread is associated with at most one instance. After the
+/// constructor is called once, subsequent calls on the same thread return
+/// the same instance.
 #[pyclass(unsendable, module = "denopy")]
 struct Runtime {
     js_runtime: JsRuntime,
@@ -28,9 +30,9 @@ thread_local! {
 }
 
 macro_rules! v8_to_py {
-    ($value:expr, $scope:ident, $py:ident, $unwrap:expr) => {
+    ($value:expr, $scope:ident, $py:ident, $unwrap:expr, $convert_safe_integers:expr) => {
         RUNTIME.with(|cell| types::v8_to_py(
-            $value, $scope, cell.borrow().as_ref().unwrap(), $py, $unwrap,
+            $value, $scope, cell.borrow().as_ref().unwrap(), $py, $unwrap, $convert_safe_integers
         ))
     }
 }
@@ -59,24 +61,35 @@ impl Runtime {
     }
 
     /// Convert a wrapped JavaScript value into its Python equivalent.
-    fn unwrap(&mut self, py: Python<'_>, value: &PyAny) -> PyResult<PyObject> {
+    ///
+    /// JavaScript numbers that are valid 32-bit integers are converted into
+    /// Python ints. Other numbers are converted to Python floats.
+    /// When 'convert_safe_integers' is True, JavaScript numbers that are safe
+    /// integers are also converted into Python ints.
+    #[pyo3(signature = (value, *, convert_safe_integers = false))]
+    fn unwrap(&mut self, py: Python<'_>, value: &PyAny, convert_safe_integers: bool) -> PyResult<PyObject> {
         let scope = &mut self.js_runtime.handle_scope();
         // TODO: Don't create JS values unnecessarily.
         let js_value = types::py_to_v8(value, scope)?;
-        v8_to_py!(js_value, scope, py, true)
+        v8_to_py!(js_value, scope, py, true, convert_safe_integers)
     }
 
     /// Return the value of a JavaScript object's property.
     ///
     /// The result may be a wrapped JavaScript value, unless 'unwrap' is True.
-    #[pyo3(signature = (object, property, *, unwrap = false))]
-    fn get(&mut self, py: Python<'_>, object: &PyAny, property: &PyAny, unwrap: bool) -> PyResult<PyObject> {
+    ///
+    /// JavaScript numbers that are valid 32-bit integers are converted into
+    /// Python ints. Other numbers are converted to Python floats.
+    /// When 'convert_safe_integers' is True, JavaScript numbers that are safe
+    /// integers are also converted into Python ints.
+    #[pyo3(signature = (object, property, *, unwrap = false, convert_safe_integers = false))]
+    fn get(&mut self, py: Python<'_>, object: &PyAny, property: &PyAny, unwrap: bool, convert_safe_integers: bool) -> PyResult<PyObject> {
         let scope = &mut self.js_runtime.handle_scope();
         let js_value = types::py_to_v8(object, scope)?;
         if let Some(js_object) = js_value.to_object(scope) {
             let prop = types::py_to_v8(property, scope)?;
             if let Some(prop_value) = js_object.get(scope, prop) {
-                return v8_to_py!(Local::new(scope, prop_value), scope, py, unwrap);
+                return v8_to_py!(Local::new(scope, prop_value), scope, py, unwrap, convert_safe_integers);
             }
         }
         Ok(py.None())
@@ -84,14 +97,19 @@ impl Runtime {
 
     /// Evaluate a piece of JavaScript.
     ///
-    /// The evaluation result may contain wrapped JavaScript values,
-    /// unless 'unwrap' is True.
+    /// The evaluation result may contain wrapped JavaScript values, unless
+    /// 'unwrap' is True.
     ///
     /// The 'name' parameter is used in stack traces and error messages.
     /// It should be a literal string, otherwise its memory will be leaked.
     /// If it is None, the name "<eval>" is used.
-    #[pyo3(signature = (source_code, *, unwrap = false, name = None))]
-    fn eval(&mut self, py: Python<'_>, source_code: &str, unwrap: bool, name: Option<String>) -> PyResult<PyObject> {
+    ///
+    /// JavaScript numbers that are valid 32-bit integers are converted into
+    /// Python ints. Other numbers are converted to Python floats.
+    /// When 'convert_safe_integers' is True, JavaScript numbers that are safe
+    /// integers are also converted into Python ints.
+    #[pyo3(signature = (source_code, *, unwrap = false, name = None, convert_safe_integers = false))]
+    fn eval(&mut self, py: Python<'_>, source_code: &str, unwrap: bool, name: Option<String>, convert_safe_integers: bool) -> PyResult<PyObject> {
         let name: &'static str = match name {
             Some(s) => s.leak(),
             None => "<eval>",
@@ -99,7 +117,7 @@ impl Runtime {
         let result = self.js_runtime.execute_script(name, ModuleCode::from(source_code.to_owned()))
             .map_err(|err| JsError::new_err(err.to_string()))?;
         let scope = &mut self.js_runtime.handle_scope();
-        v8_to_py!(Local::new(scope, result), scope, py, unwrap)
+        v8_to_py!(Local::new(scope, result), scope, py, unwrap, convert_safe_integers)
     }
 
     fn load_main_module(&mut self, py: Python<'_>, path: &str) -> PyResult<PyObject> {
@@ -130,9 +148,15 @@ impl Runtime {
     ///
     /// The result may contain wrapped JavaScript values, unless 'unwrap' is True.
     ///
-    /// If 'this' is not None, the function will be called as a method, with 'this' as the receiver.
-    #[pyo3(signature = (function, * args, unwrap = false, this = None))]
-    fn call(&mut self, py: Python<'_>, function: &JsFunction, args: &PyTuple, unwrap: bool, this: Option<&PyAny>) -> PyResult<PyObject> {
+    /// If 'this' is not None, the function will be called as a method,
+    /// with 'this' as the receiver.
+    ///
+    /// JavaScript numbers that are valid 32-bit integers are converted into
+    /// Python ints. Other numbers are converted to Python floats.
+    /// When 'convert_safe_integers' is True, JavaScript numbers that are safe
+    /// integers are also converted into Python ints.
+    #[pyo3(signature = (function, * args, unwrap = false, this = None, convert_safe_integers = false))]
+    fn call(&mut self, py: Python<'_>, function: &JsFunction, args: &PyTuple, unwrap: bool, this: Option<&PyAny>, convert_safe_integers: bool) -> PyResult<PyObject> {
         let scope = &mut self.js_runtime.handle_scope();
         let this = match this {
             Some(object) => types::py_to_v8(object, scope)?,
@@ -145,7 +169,7 @@ impl Runtime {
         let return_result = function.inner.open(scope).call(scope, this, &args);
         if let Some(exception) = scope.exception() {
             let js_error = deno_core::error::JsError::from_v8_exception(scope, exception);
-            let exception = v8_to_py!(exception, scope, py, unwrap)?;
+            let exception = v8_to_py!(exception, scope, py, unwrap, convert_safe_integers)?;
             let py_err = JsError::new_err(js_error.to_string());
             // XXX: We want readable traceback, so JsError.__str__ should only contain the formatted
             //  JS stacktrace. Since we don't know how to customize that, we attach the thrown value
@@ -153,7 +177,7 @@ impl Runtime {
             py_err.to_object(py).setattr(py, "value", exception)?;
             Err(py_err)
         } else if let Some(result) = return_result {
-            v8_to_py!(Local::new(scope, result), scope, py, unwrap)
+            v8_to_py!(Local::new(scope, result), scope, py, unwrap, convert_safe_integers)
         } else {
             Ok(py.None())
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,7 @@ impl Runtime {
     ///   - 'safe': Whole numbers within the safe-integer range.
     ///   - 'i32': Only valid 32-bit integers.
     ///   - 'never': Whole numbers are converted into 'float'.
-    #[pyo3(signature = (value, *, integer_conversion = "i32"))]
+    #[pyo3(signature = (value, *, integer_conversion = "safe"))]
     fn unwrap(&mut self, py: Python<'_>, value: &PyAny, integer_conversion: &str) -> PyResult<PyObject> {
         let scope = &mut self.js_runtime.handle_scope();
         // TODO: Don't create JS values unnecessarily.
@@ -90,7 +90,7 @@ impl Runtime {
     ///   - 'safe': Whole numbers within the safe-integer range.
     ///   - 'i32': Only valid 32-bit integers.
     ///   - 'never': Whole numbers are converted into 'float'.
-    #[pyo3(signature = (object, property, *, unwrap = false, integer_conversion = "i32"))]
+    #[pyo3(signature = (object, property, *, unwrap = false, integer_conversion = "safe"))]
     fn get(&mut self, py: Python<'_>, object: &PyAny, property: &PyAny, unwrap: bool, integer_conversion: &str) -> PyResult<PyObject> {
         let scope = &mut self.js_runtime.handle_scope();
         let js_value = types::py_to_v8(object, scope)?;
@@ -120,7 +120,7 @@ impl Runtime {
     ///   - 'safe': Whole numbers within the safe-integer range.
     ///   - 'i32': Only valid 32-bit integers.
     ///   - 'never': Whole numbers are converted into 'float'.
-    #[pyo3(signature = (source_code, *, unwrap = false, name = None, integer_conversion = "i32"))]
+    #[pyo3(signature = (source_code, *, unwrap = false, name = None, integer_conversion = "safe"))]
     fn eval(&mut self, py: Python<'_>, source_code: &str, unwrap: bool, name: Option<String>, integer_conversion: &str) -> PyResult<PyObject> {
         let name: &'static str = match name {
             Some(s) => s.leak(),
@@ -171,7 +171,7 @@ impl Runtime {
     ///   - 'safe': Whole numbers within the safe-integer range.
     ///   - 'i32': Only valid 32-bit integers.
     ///   - 'never': Whole numbers are converted into 'float'.
-    #[pyo3(signature = (function, * args, unwrap = false, this = None, integer_conversion = "i32"))]
+    #[pyo3(signature = (function, * args, unwrap = false, this = None, integer_conversion = "safe"))]
     fn call(&mut self, py: Python<'_>, function: &JsFunction, args: &PyTuple, unwrap: bool, this: Option<&PyAny>, integer_conversion: &str) -> PyResult<PyObject> {
         let scope = &mut self.js_runtime.handle_scope();
         let this = match this {

--- a/src/types.rs
+++ b/src/types.rs
@@ -83,8 +83,6 @@ pub fn v8_to_py(value: Local<Value>, scope: &mut HandleScope, runtime: &Py<Runti
         Ok(value.boolean_value(scope).into_py(py))
     } else if value.is_int32() {
         Ok(value.int32_value(scope).unwrap().into_py(py))
-    } else if value.is_uint32() {
-        Ok(value.uint32_value(scope).unwrap().into_py(py))
     } else if value.is_number() {
         let f = value.number_value(scope).unwrap();
         if convert_safe_integers && f.trunc() == f {

--- a/src/types.rs
+++ b/src/types.rs
@@ -16,7 +16,7 @@ pub struct JsFunction {
 
 #[pymethods]
 impl JsFunction {
-    #[pyo3(signature = (* args, unwrap = false, this = None, integer_conversion = "i32"))]
+    #[pyo3(signature = (* args, unwrap = false, this = None, integer_conversion = "safe"))]
     fn __call__(&self, py: Python<'_>, args: &PyTuple, unwrap: bool, this: Option<&PyAny>, integer_conversion: &str) -> PyResult<PyObject> {
         self.runtime.borrow_mut(py).call(py, self, args, unwrap, this, integer_conversion)
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -79,7 +79,12 @@ pub fn v8_to_py(value: Local<Value>, scope: &mut HandleScope, runtime: &Py<Runti
     } else if value.is_uint32() {
         Ok(value.uint32_value(scope).unwrap().into_py(py))
     } else if value.is_number() {
-        Ok(value.number_value(scope).unwrap().into_py(py))
+        let f = value.number_value(scope).unwrap();
+        if f.trunc() == f {
+            Ok((f as i64).into_py(py))
+        } else {
+            Ok(f.into_py(py))
+        }
     } else if let Result::<Local<v8::Function>, _>::Ok(function) = value.try_into() {
         Ok(JsFunction {
             inner: Global::new(scope, function),

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -12,9 +12,13 @@ def identity(runtime):
     return runtime.eval("x => x")
 
 
-def test_numbers(runtime):
+def test_numbers(runtime, identity):
     for n in [1, 1.0, -5, -7.5]:
         assert runtime.eval(f"{n}") == n
+        assert identity(n) == n
+        if isinstance(n, float) and n.is_integer():
+            continue
+        assert type(identity(n)) == type(n)
 
 
 def test_strings(runtime):
@@ -22,7 +26,7 @@ def test_strings(runtime):
 
 
 def test_roundtrips(runtime, identity):
-    for v in ["abc", 1, 5.3, True, False, None,
+    for v in ["abc", 1, 1.0, 5.3, True, False, None,
               [], [2, 3.4, "x"],
               {}, {'a': 5, 'b': ['x', dict(c=None)]}]:
         assert runtime.call(identity, v, unwrap=True) == v

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -28,8 +28,10 @@ def test_small_integers(runtime, identity):
     for n in [2 ** 8, 2 ** 16, 2 ** 31 - 1, -(2 ** 31)]:
         assert_eq_type(n, runtime.eval(f"{n}"))
         assert_eq_type(n, identity(n))
-        assert_eq_type(n, runtime.eval(f"{n}", convert_safe_integers=True))
-        assert_eq_type(n, identity(n, convert_safe_integers=True))
+        assert_eq_type(n, runtime.eval(f"{n}", integer_conversion='safe'))
+        assert_eq_type(n, identity(n, integer_conversion='safe'))
+        assert_eq_type(float(n), runtime.eval(f"{n}", integer_conversion='never'))
+        assert_eq_type(float(n), identity(n, integer_conversion='never'))
         # Even if it's a whole float.
         assert_eq_type(n, runtime.eval(f"{float(n)}"))
         assert_eq_type(n, identity(float(n)))
@@ -42,8 +44,8 @@ def test_safe_integers(runtime, identity):
         assert_eq_type(float(n), runtime.eval(f"{n}"))
         assert_eq_type(float(n), identity(n))
         # Nice behavior.
-        assert_eq_type(n, runtime.eval(f"{n}", convert_safe_integers=True))
-        assert_eq_type(n, identity(n, convert_safe_integers=True))
+        assert_eq_type(n, runtime.eval(f"{n}", integer_conversion='safe'))
+        assert_eq_type(n, identity(n, integer_conversion='safe'))
 
 
 def test_unsafe_integers(runtime, identity):
@@ -51,9 +53,9 @@ def test_unsafe_integers(runtime, identity):
     for n in [2 ** 53, - (2 ** 53), 2 ** 64, -(2 ** 64)]:
         assert_eq_type(float(n), runtime.eval(f"{n}"))
         assert_eq_type(float(n), identity(n))
-        # Even with aggressive conversion.
-        assert_eq_type(float(n), runtime.eval(f"{n}", convert_safe_integers=True))
-        assert_eq_type(float(n), identity(n, convert_safe_integers=True))
+        # Even with 'safe' conversion.
+        assert_eq_type(float(n), runtime.eval(f"{n}", integer_conversion='safe'))
+        assert_eq_type(float(n), identity(n, integer_conversion='safe'))
 
 
 def test_strings(runtime):

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -12,13 +12,48 @@ def identity(runtime):
     return runtime.eval("x => x")
 
 
-def test_numbers(runtime, identity):
-    for n in [1, 1.0, -5, -7.5]:
-        assert runtime.eval(f"{n}") == n
-        assert identity(n) == n
-        if isinstance(n, float) and n.is_integer():
-            continue
-        assert type(identity(n)) == type(n)
+def assert_eq_type(expected_value, actual):
+    assert actual == expected_value
+    assert isinstance(actual, type(expected_value))
+
+
+def test_floats(runtime, identity):
+    for f in [1.5, 0.1, -10.2]:
+        assert_eq_type(f, runtime.eval(f"{f}"))
+        assert_eq_type(f, identity(f))
+
+
+def test_small_integers(runtime, identity):
+    # Fit into i32. Always int.
+    for n in [2 ** 8, 2 ** 16, 2 ** 31 - 1, -(2 ** 31)]:
+        assert_eq_type(n, runtime.eval(f"{n}"))
+        assert_eq_type(n, identity(n))
+        assert_eq_type(n, runtime.eval(f"{n}", convert_safe_integers=True))
+        assert_eq_type(n, identity(n, convert_safe_integers=True))
+        # Even if it's a whole float.
+        assert_eq_type(n, runtime.eval(f"{float(n)}"))
+        assert_eq_type(n, identity(float(n)))
+
+
+def test_safe_integers(runtime, identity):
+    # Fit into JavaScript safe integer range (f64 has 53-bit mantissa).
+    for n in [2 ** 31, 2 ** 32, 2 ** 53 - 1, -(2 ** 53 - 1)]:
+        # Default behavior.
+        assert_eq_type(float(n), runtime.eval(f"{n}"))
+        assert_eq_type(float(n), identity(n))
+        # Nice behavior.
+        assert_eq_type(n, runtime.eval(f"{n}", convert_safe_integers=True))
+        assert_eq_type(n, identity(n, convert_safe_integers=True))
+
+
+def test_unsafe_integers(runtime, identity):
+    # Don't fit into the above. Always float.
+    for n in [2 ** 53, - (2 ** 53), 2 ** 64, -(2 ** 64)]:
+        assert_eq_type(float(n), runtime.eval(f"{n}"))
+        assert_eq_type(float(n), identity(n))
+        # Even with aggressive conversion.
+        assert_eq_type(float(n), runtime.eval(f"{n}", convert_safe_integers=True))
+        assert_eq_type(float(n), identity(n, convert_safe_integers=True))
 
 
 def test_strings(runtime):

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -26,23 +26,23 @@ def test_floats(runtime, identity):
 def test_small_integers(runtime, identity):
     # Fit into i32. Always int.
     for n in [2 ** 8, 2 ** 16, 2 ** 31 - 1, -(2 ** 31)]:
+        assert_eq_type(n, runtime.eval(f"{n}", integer_conversion='i32'))
+        assert_eq_type(n, identity(n, integer_conversion='i32'))
         assert_eq_type(n, runtime.eval(f"{n}"))
         assert_eq_type(n, identity(n))
-        assert_eq_type(n, runtime.eval(f"{n}", integer_conversion='safe'))
-        assert_eq_type(n, identity(n, integer_conversion='safe'))
         assert_eq_type(float(n), runtime.eval(f"{n}", integer_conversion='never'))
         assert_eq_type(float(n), identity(n, integer_conversion='never'))
         # Even if it's a whole float.
-        assert_eq_type(n, runtime.eval(f"{float(n)}"))
-        assert_eq_type(n, identity(float(n)))
+        assert_eq_type(n, runtime.eval(f"{float(n)}", integer_conversion='i32'))
+        assert_eq_type(n, identity(float(n), integer_conversion='i32'))
 
 
 def test_safe_integers(runtime, identity):
     # Fit into JavaScript safe integer range (f64 has 53-bit mantissa).
     for n in [2 ** 31, 2 ** 32, 2 ** 53 - 1, -(2 ** 53 - 1)]:
-        # Default behavior.
-        assert_eq_type(float(n), runtime.eval(f"{n}"))
-        assert_eq_type(float(n), identity(n))
+        # Conservative behavior.
+        assert_eq_type(float(n), runtime.eval(f"{n}", integer_conversion='i32'))
+        assert_eq_type(float(n), identity(n, integer_conversion='i32'))
         # Nice behavior.
         assert_eq_type(n, runtime.eval(f"{n}", integer_conversion='safe'))
         assert_eq_type(n, identity(n, integer_conversion='safe'))
@@ -51,9 +51,8 @@ def test_safe_integers(runtime, identity):
 def test_unsafe_integers(runtime, identity):
     # Don't fit into the above. Always float.
     for n in [2 ** 53, - (2 ** 53), 2 ** 64, -(2 ** 64)]:
-        assert_eq_type(float(n), runtime.eval(f"{n}"))
-        assert_eq_type(float(n), identity(n))
-        # Even with 'safe' conversion.
+        assert_eq_type(float(n), runtime.eval(f"{n}", integer_conversion='i32'))
+        assert_eq_type(float(n), identity(n, integer_conversion='i32'))
         assert_eq_type(float(n), runtime.eval(f"{n}", integer_conversion='safe'))
         assert_eq_type(float(n), identity(n, integer_conversion='safe'))
 


### PR DESCRIPTION
- Widen the range of JavaScript whole numbers that are converted into Python `int` by default, to cover all of the safe-integer range.
- Make the conversion's behavior more controllable.